### PR TITLE
Remove references

### DIFF
--- a/src/Concerns/AutoloadsRelationships.php
+++ b/src/Concerns/AutoloadsRelationships.php
@@ -137,8 +137,8 @@ trait AutoloadsRelationships
         $collection = new Collection($models);
         unset($models);
 
-        foreach ($collection as &$model) {
-            $model->parentCollection = &$collection;
+        foreach ($collection as $model) {
+            $model->parentCollection = $collection;
         }
 
         return $collection;


### PR DESCRIPTION
As objects, `$model` and `$collection` are always passed by reference.