### PR TITLE
Fix model name not being correct if extending base

### DIFF
--- a/src/Concerns/AutoloadsRelationships.php
+++ b/src/Concerns/AutoloadsRelationships.php
@@ -90,7 +90,7 @@ trait AutoloadsRelationships
 
         $blade = $this->getBlade($file);
 
-        $this->logDriver->info("[LARAVEL-JIT-LOADER] Relationship ". self::class."::{$relationship} was JIT-loaded."
+        $this->logDriver->info("[LARAVEL-JIT-LOADER] Relationship ". static::class."::{$relationship} was JIT-loaded."
             ." Called in {$file} on line {$lineNo} " . ($blade ? "view: {$blade})" : ""));
     }
 


### PR DESCRIPTION
Hello,

I extend all my models from a base model, so the logs all say: `[LARAVEL-JIT-LOADER] Relationship App\Entities\Entity::{relationship} was JIT-loaded.`

Using `static::class` instead of `self::class` fixes this.

Fantastic package! 👍