### PR TITLE
Improve performance

### DIFF
--- a/src/Concerns/AutoloadsRelationships.php
+++ b/src/Concerns/AutoloadsRelationships.php
@@ -113,7 +113,7 @@ trait AutoloadsRelationships
 
         if ($this->shouldAutoLoad()) {
             if (!$this->relationLoaded($method)) {
-                $stack = debug_backtrace()[3];
+                $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4)[3];
                 $this->logAutoload($method, $stack['file'], $stack['line']);
                 $this->parentCollection->loadMissing($method);
 


### PR DESCRIPTION
By default, the backtrace includes the model, the method arguments and *all* stack frames. We can remove the unnecessary data and limit the frames.

It would be even better to only call `debug_backtrace()` in `logAutoload()` if the `$logChannel` is set.