### PR TITLE
Support Laravel 5.5

### DIFF
--- a/src/Concerns/AutoloadsRelationships.php
+++ b/src/Concerns/AutoloadsRelationships.php
@@ -115,7 +115,7 @@ trait AutoloadsRelationships
             if (!$this->relationLoaded($method)) {
                 $stack = debug_backtrace()[3];
                 $this->logAutoload($method, $stack['file'], $stack['line']);
-                $this->parentCollection->loadMissing($method);
+                $this->parentCollection->load($method);
 
                 return current($this->parentCollection->getIterator())->relations[$method];
             }


### PR DESCRIPTION
`Collection::loadMissing()` was only added in Laravel 5.6.22.

I also think it's unnecessary: We already check if the relationship is loaded with `relationLoaded()`.