### PR TITLE
Use context data for logging

### DIFF
--- a/src/Concerns/AutoloadsRelationships.php
+++ b/src/Concerns/AutoloadsRelationships.php
@@ -90,13 +90,12 @@ trait AutoloadsRelationships
 
         $this->getLogDriver();
 
-        $file = $stack['file'];
-        $lineNo = $stack['line'];
-
-        $blade = $this->getBlade($file);
-
-        $this->logDriver->info("[LARAVEL-JIT-LOADER] Relationship ". static::class."::{$relationship} was JIT-loaded."
-            ." Called in {$file} on line {$lineNo}" . ($blade ? " view: {$blade})" : ""));
+        $this->logDriver->info('[LARAVEL-JIT-LOADER] Relationship was JIT-loaded.', [
+            'relationship' => static::class.'::'.$relationship,
+            'file' => $stack['file'],
+            'line' => $stack['line'],
+            'view' => $this->getBlade($file),
+        ]);
     }
 
     /**

--- a/src/Concerns/AutoloadsRelationships.php
+++ b/src/Concerns/AutoloadsRelationships.php
@@ -90,9 +90,11 @@ trait AutoloadsRelationships
 
         $this->getLogDriver();
 
+        $file = $stack['file'];
+        
         $this->logDriver->info('[LARAVEL-JIT-LOADER] Relationship was JIT-loaded.', [
             'relationship' => static::class.'::'.$relationship,
-            'file' => $stack['file'],
+            'file' => $file,
             'line' => $stack['line'],
             'view' => $this->getBlade($file),
         ]);


### PR DESCRIPTION
This makes programmatically filtering through the log messages (in tools like [Laravel Telescope](https://github.com/laravel/telescope)) a lot easier.