### PR TITLE
Add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
 	}],
 	"require": {
 		"php": ">=7.1.0",
-		"illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0"
+		"illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7.0.0",
 		"squizlabs/php_codesniffer": "^3.0.0",
 		"phpunit/php-code-coverage": "^6.0.0",
-		"illuminate/log": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0"
+		"illuminate/log": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
I am unaware of any changes to models that require any modifications, but if there are some please let me know.

I tested this in a sample project, but my main project that relies heavily on JIT relationships can't be upgraded to Laravel 8 yet. I'm waiting for a few more packages still (which I am PRing today, so hopefully soon). If you want to hold off on a release until I test it fully on my project, that's fine. I can use `dev-master` until then.